### PR TITLE
Fix: Improve modal scrolling and overall keyboard/screen-reader accessibility

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -196,6 +196,10 @@
         {
           "label": "Close window",
           "default": "Close window"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/de.json
+++ b/language/de.json
@@ -196,6 +196,10 @@
         {
           "label": "Fenster schließen",
           "default": "Fenster schließen"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/el.json
+++ b/language/el.json
@@ -196,6 +196,10 @@
         {
           "label": "Κλείσιμο παραθύρου",
           "default": "Κλείσιμο παραθύρου"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -196,6 +196,10 @@
         {
           "label": "Cerrar ventana",
           "default": "Cerrar ventana"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/es.json
+++ b/language/es.json
@@ -196,6 +196,10 @@
         {
           "label": "Cerrrar ventana",
           "default": "Cerrrar ventana"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/eu.json
+++ b/language/eu.json
@@ -196,6 +196,10 @@
         {
           "label": "Itxi leihoa",
           "default": "Itxi leihoa"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/gl.json
+++ b/language/gl.json
@@ -196,6 +196,10 @@
         {
           "label": "Pechar xanela",
           "default": "Pechar xanela"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/nl.json
+++ b/language/nl.json
@@ -196,6 +196,10 @@
         {
           "label": "Scherm sluiten",
           "default": "Scherm sluiten"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -1,0 +1,207 @@
+{
+  "semantics": [
+    {
+      "label": "Modo para imagens das portas",
+      "description": "Selecione se deseja definir cada imagem personalizada das portas manualmente ou se prefere que o H5P faça o trabalho para você com base na imagem de fundo do calendário definida nas configurações de comportamento.",
+      "options": [
+        {
+          "label": "Quero definir cada imagem de porta manualmente"
+        },
+        {
+          "label": "O H5P deve definir as imagens das portas com base na imagem de fundo"
+        }
+      ]
+    },
+    {
+      "label": "Portas",
+      "entity": "porta",
+      "field": {
+        "fields": [
+          {
+            "label": "Tipo de conteúdo",
+            "description": "Tipo de conteúdo que deve opcionalmente aparecer quando a porta for aberta.",
+            "options": [
+              {
+                "label": "Áudio"
+              },
+              {
+                "label": "Imagem"
+              },
+              {
+                "label": "Link"
+              },
+              {
+                "label": "Texto"
+              },
+              {
+                "label": "Vídeo"
+              }
+            ]
+          },
+          {
+            "label": "Áudio"
+          },
+          {
+            "label": "Imagem"
+          },
+          {
+            "label": "Link"
+          },
+          {
+            "label": "Texto"
+          },
+          {
+            "label": "Vídeo"
+          },
+          {
+            "label": "Reprodução automática"
+          },
+          {
+            "label": "Imagem da porta",
+            "description": "Imagem que será usada para a porta. Precisa ter uma proporção de 1:1 se você quiser que a metade esquerda se ajuste à metade direita."
+          },
+          {
+            "label": "Imagem de fundo",
+            "description": "Imagem que deve aparecer dentro da porta. Por padrão, será o número da porta."
+          }
+        ]
+      },
+      "widgets": [
+        {
+          "label": "Padrão"
+        }
+      ]
+    },
+    {
+      "label": "Configurações visuais",
+      "description": "Essas opções permitem configurar a aparência visual.",
+      "fields": [
+        {
+          "label": "Imagem de fundo do calendário"
+        },
+        {
+          "label": "Modelo de imagem da porta",
+          "description": "Se uma imagem for definida, ela será usada para todas as portas, a menos que uma imagem específica seja definida para uma única porta."
+        },
+        {
+          "label": "Ocultar borda da porta"
+        },
+        {
+          "label": "Ocultar números da porta"
+        },
+        {
+          "label": "Ocultar maçanetas da porta"
+        },
+        {
+          "label": "Ocultar moldura da porta"
+        },
+        {
+          "label": "Deixe nevar",
+          "description": "Adicionará um efeito de neve caindo na frente do calendário. Nunca chove no sul da Califórnia, nunca neva no IE11."
+        }
+      ]
+    },
+    {
+      "label": "Configurações de áudio",
+      "description": "Essas opções permitem configurar os elementos de áudio.",
+      "fields": [
+        {
+          "label": "Música de fundo"
+        },
+        {
+          "label": "Reprodução automática da música de fundo",
+          "description": "Se definido, a música de fundo tocará automaticamente assim que o conteúdo for aberto. Observação: as políticas de mídia de alguns navegadores podem impedir a reprodução automática."
+        }
+      ]
+    },
+    {
+      "label": "Configurações de comportamento",
+      "description": "Essas opções permitem sobrepor as configurações de comportamento padrão.",
+      "fields": [
+        {
+          "label": "Modo de posicionamento das portas",
+          "description": "Selecione se deseja definir um número fixo de colunas e linhas para as portas ou se o H5P deve decidir dinamicamente dependendo do espaço disponível. Observe que a última opção pode interferir na posição da imagem de fundo e das imagens de capa personalizadas que deveriam estar em uma posição específica.",
+          "options": [
+            {
+              "label": "Fixo"
+            },
+            {
+              "label": "Dinâmico"
+            }
+          ]
+        },
+        {
+          "label": "Proporção de linhas para colunas",
+          "description": "Selecione quantas colunas e linhas o calendário deve usar.",
+          "options": [
+            {
+              "label": "6 × 4"
+            },
+            {
+              "label": "4 × 6"
+            }
+          ]
+        },
+        {
+          "label": "Ordem aleatória",
+          "description": "Embaralha a ordem das portas. Se a opção \"salvar estado do conteúdo\" estiver ativada nas configurações do H5P, essa ordem permanecerá a mesma quando o usuário retornar mais tarde."
+        },
+        {
+          "label": "Manter a ordem das imagens",
+          "description": "Embaralha as portas, mas mantém as imagens de capa das portas em suas posições fixas, começando com a 1 no canto superior esquerdo até a 24 no canto inferior direito."
+        },
+        {
+          "label": "Modo de edição/design",
+          "description": "No modo de design, todas as portas podem ser abertas. Caso contrário, as portas só poderão ser abertas em dezembro, a partir do respectivo dia indicado no número da porta."
+        }
+      ]
+    },
+    {
+      "label": "Localização",
+      "fields": [
+        {
+          "label": "Nada para ver",
+          "default": "Não há nada para ver aqui!\ud83c\udf84"
+        },
+        {
+          "label": "Fictício (Dummy)",
+          "default": "Fictício"
+        }
+      ]
+    },
+    {
+      "label": "Acessibilidade",
+      "fields": [
+        {
+          "label": "Porta",
+          "default": "Porta"
+        },
+        {
+          "label": "Bloqueada",
+          "default": "Bloqueada. Ainda não está na hora de abrir esta porta."
+        },
+        {
+          "description": "Anuncia o conteúdo. @door é uma variável e será substituída pela descrição da porta relacionada.",
+          "label": "Conteúdo de",
+          "default": "Conteúdo da @door"
+        },
+        {
+          "label": "Mudar para mudo",
+          "default": "Desativar som"
+        },
+        {
+          "label": "Ativar som",
+          "default": "Ativar som"
+        },
+        {
+          "label": "Fechar janela",
+          "default": "Fechar janela"
+        },
+        {
+          "label": "Carregando",
+          "default": "Carregando..."
+        }
+      ]
+    }
+  ]
+}

--- a/language/ro.json
+++ b/language/ro.json
@@ -196,6 +196,10 @@
         {
           "label": "Închide fereastra",
           "default": "Închide fereastra"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/language/sl.json
+++ b/language/sl.json
@@ -196,6 +196,10 @@
         {
           "label": "Zapri okno",
           "default": "Zapri okno"
+        },
+        {
+          "label": "Loading",
+          "default": "Loading..."
         }
       ]
     }

--- a/semantics.json
+++ b/semantics.json
@@ -434,6 +434,13 @@
         "label": "Close window",
         "importance": "low",
         "default": "Close window"
+      },
+      {
+        "name": "loading",
+        "type": "text",
+        "label": "Loading",
+        "importance": "low",
+        "default": "Loading..."
       }
     ]
   }

--- a/src/scripts/components/h5p-advent-calendar-door.js
+++ b/src/scripts/components/h5p-advent-calendar-door.js
@@ -18,6 +18,9 @@ export default class AdventCalendarDoor {
       onLoaded: () => {},
     }, callbacks);
 
+    this.handleClick = this.handleClick.bind(this);
+    this.handleKeydown = this.handleKeydown.bind(this);
+
     this.opened = false;
     this.toLoad = ['door', 'previewImage'];
 
@@ -45,12 +48,8 @@ export default class AdventCalendarDoor {
     if (!this.canBeOpened()) {
       this.container.classList.add('h5p-advent-calendar-disabled');
     }
-    this.container.addEventListener('click', (event) => {
-      this.handleClick(event);
-    });
-    this.container.addEventListener('keypress', (event) => {
-      this.handleKeypress(event);
-    });
+    this.container.addEventListener('click', this.handleClick);
+    this.container.addEventListener('keydown', this.handleKeydown);
 
     // Door container
     const doorContainer = document.createElement('div');
@@ -220,8 +219,8 @@ export default class AdventCalendarDoor {
    * Handle open event by space/enter.
    * @param {Event} event Event.
    */
-  handleKeypress(event) {
-    if (event.code === 'Space' || event.code === 'Enter') {
+  handleKeydown(event) {
+    if (event.key === ' ' || event.key === 'Enter') {
       // Forward to click handler, door has role="button".
       this.handleClick(event);
     }
@@ -240,12 +239,8 @@ export default class AdventCalendarDoor {
 
     this.open();
 
-    this.container.removeEventListener('click', (event) => {
-      this.handleClick(event);
-    });
-    this.container.removeEventListener('keypress', (event) => {
-      this.handleKeypress(event);
-    });
+    this.container.removeEventListener('click', this.handleClick);
+    this.container.removeEventListener('keydown', this.handleKeydown);
   }
 
   /**

--- a/src/scripts/components/h5p-advent-calendar-overlay.js
+++ b/src/scripts/components/h5p-advent-calendar-overlay.js
@@ -185,7 +185,7 @@ export default class Overlay {
       this.updateFocusableElements(); // Won't find YouTube elements in iframe
 
       const focusableInContent = this.focusableElements.filter(
-        (element) => this.content.contains(element)
+        (element) => this.content.contains(element),
       );
 
       if (focusableInContent.length === 0) {

--- a/src/scripts/components/h5p-advent-calendar-overlay.js
+++ b/src/scripts/components/h5p-advent-calendar-overlay.js
@@ -61,6 +61,13 @@ export default class Overlay {
       this.trapFocus(event);
     }, true);
 
+    // Close on Escape key
+    document.addEventListener('keydown', (event) => {
+      if (this.isVisible && (event.key === 'Escape' || event.key === 'Esc')) {
+        this.callbacks.onClose();
+      }
+    });
+
     // Blocker
     this.blocker = document.createElement('div');
     this.blocker.classList.add('h5p-advent-calendar-overlay-blocker');

--- a/src/scripts/components/h5p-advent-calendar-overlay.js
+++ b/src/scripts/components/h5p-advent-calendar-overlay.js
@@ -189,11 +189,13 @@ export default class Overlay {
       );
 
       if (focusableInContent.length === 0) {
-        this.content.setAttribute('tabindex', '0');
+        const firstChild = this.content.querySelector('.h5p-advent-calendar-instance-wrapper')?.firstChild;
+
+        firstChild?.setAttribute('tabindex', '0');
         this.updateFocusableElements();
 
-        this.content.addEventListener('blur', () => {
-          this.content.removeAttribute('tabindex');
+        firstChild?.addEventListener('blur', () => {
+          firstChild.removeAttribute('tabindex');
           this.updateFocusableElements();
         }, { once: true });
       }

--- a/src/scripts/components/h5p-advent-calendar-overlay.js
+++ b/src/scripts/components/h5p-advent-calendar-overlay.js
@@ -41,7 +41,6 @@ export default class Overlay {
 
     this.content = document.createElement('div');
     this.content.classList.add(`${this.params.styleBase}-content`);
-    this.content.setAttribute('tabindex', '0');
     this.content.appendChild(this.params.content);
     this.overlay.appendChild(this.content);
 
@@ -62,7 +61,6 @@ export default class Overlay {
       this.trapFocus(event);
     }, true);
 
-    // Close on Escape key
     document.addEventListener('keydown', (event) => {
       if (this.isVisible && (event.key === 'Escape' || event.key === 'Esc')) {
         this.callbacks.onClose();
@@ -185,6 +183,20 @@ export default class Overlay {
 
     setTimeout(() => {
       this.updateFocusableElements(); // Won't find YouTube elements in iframe
+
+      const focusableInContent = this.focusableElements.filter(
+        (element) => this.content.contains(element)
+      );
+
+      if (focusableInContent.length === 0) {
+        this.content.setAttribute('tabindex', '0');
+        this.updateFocusableElements();
+
+        this.content.addEventListener('blur', () => {
+          this.content.removeAttribute('tabindex');
+          this.updateFocusableElements();
+        }, { once: true });
+      }
 
       if (this.focusableElements.length > 0) {
         this.focusableElements[0].focus();

--- a/src/scripts/components/h5p-advent-calendar-overlay.js
+++ b/src/scripts/components/h5p-advent-calendar-overlay.js
@@ -41,6 +41,7 @@ export default class Overlay {
 
     this.content = document.createElement('div');
     this.content.classList.add(`${this.params.styleBase}-content`);
+    this.content.setAttribute('tabindex', '0');
     this.content.appendChild(this.params.content);
     this.overlay.appendChild(this.content);
 
@@ -164,7 +165,7 @@ export default class Overlay {
   updateFocusableElements() {
     this.focusableElements = []
       .slice.call(this.overlay.querySelectorAll(
-        'video, audio, button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        'video, audio, button, [href], input, select, textarea, iframe, [tabindex]:not([tabindex="-1"])',
       ))
       .filter((element) => element.getAttribute('disabled') !== 'true' && element.getAttribute('disabled') !== true);
   }

--- a/src/scripts/components/h5p-advent-calendar-overlay.scss
+++ b/src/scripts/components/h5p-advent-calendar-overlay.scss
@@ -12,6 +12,8 @@
   visibility: visible;
   max-width: calc(100% - 4em);
   z-index: 10;
+  display: flex;
+  flex-direction: column;
 
   &.h5p-advent-calendar-content-type-image {
     width: 80%;
@@ -33,10 +35,10 @@
     border-radius: 0.5em;
     display: flex;
     flex-direction: column;
-    flex-wrap: wrap;
-    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
     justify-content: center;
-    overflow: hidden;
+    overflow-x: hidden;
     overflow-y: auto;
     padding: 1em;
 

--- a/src/scripts/components/h5p-advent-calendar-overlay.scss
+++ b/src/scripts/components/h5p-advent-calendar-overlay.scss
@@ -35,9 +35,11 @@
     border-radius: 0.5em;
     display: flex;
     flex-direction: column;
-    flex: 1 1 auto;
+    flex-grow: 1;
+    flex-shrink: 1;
+    flex-basis: auto;
     min-height: 0;
-    justify-content: center;
+    justify-content: flex-start;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 1em;

--- a/src/scripts/components/h5p-advent-calendar-spinner.js
+++ b/src/scripts/components/h5p-advent-calendar-spinner.js
@@ -11,6 +11,8 @@ class Spinner {
 
     this.container = document.createElement('div');
     this.container.classList.add(`${this.classNameBase}-container`);
+    this.container.setAttribute('role', 'status');
+    this.container.setAttribute('aria-label', 'Loading...');
 
     this.spinnerElement = document.createElement('div');
     this.spinnerElement.classList.add(classNameBase);

--- a/src/scripts/components/h5p-advent-calendar-spinner.js
+++ b/src/scripts/components/h5p-advent-calendar-spinner.js
@@ -1,19 +1,20 @@
+import Util from '@services/h5p-advent-calendar-util.js';
 import './h5p-advent-calendar-spinner.scss';
 
 /** Class for an activity indicator aka spinner */
 class Spinner {
   /**
    * Constructor.
-   * @param {string} classNameBase Class name base to define spinner visuals.
-   * @param {object} [params]
-   * @param {object} [params.a11y]
-   * @param {string} [params.a11y.loading]
+   * @param {object} [params] Parameters.
+   * @param {string} [params.classNameBase] Class name base to define spinner visuals.
+   * @param {object} [params.a11y] Accessibility strings.
    */
-  constructor(classNameBase, params = {}) {
-    this.classNameBase = classNameBase;
-    this.params = params || {};
-    this.params.a11y = this.params.a11y || {};
-    this.params.a11y.loading = this.params.a11y.loading || 'Loading...';
+  constructor(params = {}) {
+    this.params = Util.extend({
+      loading: 'Loading...',
+    }, params);
+
+    this.classNameBase = this.params.classNameBase;
 
     this.container = document.createElement('div');
     this.container.classList.add(`${this.classNameBase}-container`);
@@ -21,7 +22,7 @@ class Spinner {
     this.container.setAttribute('aria-label', this.params.a11y.loading);
 
     this.spinnerElement = document.createElement('div');
-    this.spinnerElement.classList.add(classNameBase);
+    this.spinnerElement.classList.add(this.classNameBase);
 
     // Circle parts with different delays for the grow/shrink animation
     const circleHead = document.createElement('div');

--- a/src/scripts/components/h5p-advent-calendar-spinner.js
+++ b/src/scripts/components/h5p-advent-calendar-spinner.js
@@ -5,14 +5,20 @@ class Spinner {
   /**
    * Constructor.
    * @param {string} classNameBase Class name base to define spinner visuals.
+   * @param {object} [params]
+   * @param {object} [params.a11y]
+   * @param {string} [params.a11y.loading]
    */
-  constructor(classNameBase) {
+  constructor(classNameBase, params = {}) {
     this.classNameBase = classNameBase;
+    this.params = params || {};
+    this.params.a11y = this.params.a11y || {};
+    this.params.a11y.loading = this.params.a11y.loading || 'Loading...';
 
     this.container = document.createElement('div');
     this.container.classList.add(`${this.classNameBase}-container`);
     this.container.setAttribute('role', 'status');
-    this.container.setAttribute('aria-label', 'Loading...');
+    this.container.setAttribute('aria-label', this.params.a11y.loading);
 
     this.spinnerElement = document.createElement('div');
     this.spinnerElement.classList.add(classNameBase);

--- a/src/scripts/h5p-advent-calendar.js
+++ b/src/scripts/h5p-advent-calendar.js
@@ -174,7 +174,8 @@ export default class AdventCalendar extends H5P.EventDispatcher {
     this.container.classList.add('h5p-advent-calendar-container');
 
     // Spinner to indicate loading
-    this.spinner = new Spinner('h5p-advent-calendar-spinner', {
+    this.spinner = new Spinner({
+      classNameBase: 'h5p-advent-calendar-spinner',
       a11y: {
         loading: this.params.a11y.loading,
       },

--- a/src/scripts/h5p-advent-calendar.js
+++ b/src/scripts/h5p-advent-calendar.js
@@ -72,6 +72,7 @@ export default class AdventCalendar extends H5P.EventDispatcher {
         closeWindow: 'Close window',
         mute: 'Mute audio',
         unmute: 'Unmute audio',
+        loading: 'Loading...',
       },
     }, params);
 
@@ -173,7 +174,11 @@ export default class AdventCalendar extends H5P.EventDispatcher {
     this.container.classList.add('h5p-advent-calendar-container');
 
     // Spinner to indicate loading
-    this.spinner = new Spinner('h5p-advent-calendar-spinner');
+    this.spinner = new Spinner('h5p-advent-calendar-spinner', {
+      a11y: {
+        loading: this.params.a11y.loading,
+      },
+    });
     this.container.appendChild(this.spinner.getDOM());
 
     // Main table


### PR DESCRIPTION
Hi! This PR have a few improvements to accessibility and CSS layout in the modal overlay.

- Replaced deprecated `keypress` with `keydown`.
- Fixed a minor memory leak/logic bug where `removeEventListener` was failing to remove anonymous arrow functions. 
- Support to close modal overlay by `Escape` key.
- Added iframe to the `querySelectorAll` list of `focusableElements` in the overlay so that YouTube videos are properly trapped in the focus loop and can be played via keyboard without relying on backwards-tabbing.
- Added `tabindex="0"` to the `.h5p-advent-calendar-overlay-content` container. This is to focus lands on the content first (today lands in the close button first).
- Fixed an issue where long text inside the modal was expanding beyond the screen and getting clipped vertically instead of scrolling. 

Thank you for your time reviewing this!